### PR TITLE
Introduced minimum N for matches

### DIFF
--- a/application/fingerprint-docker-image/lambda-entry-check.ts
+++ b/application/fingerprint-docker-image/lambda-entry-check.ts
@@ -48,6 +48,9 @@ type EventInput = {
     // the relatedness threshold to report against
     relatednessThreshold: number;
 
+    // a minimum N count that we need to meet to report against
+    minimumNCount: number;
+
     // if present a regex that is matched to BAM filenames (i.e. not against the hex encoded keys)
     // and tells us to exclude them from sending to "somalier relate"
     excludeRegex?: string;
@@ -172,7 +175,8 @@ export const lambdaHandler = async (ev: EventInput, context: any) => {
       ev.BatchInput.fingerprintFolder,
       indexSampleIdToFingerprintKeyMap,
       sampleIdToFingerprintKeyMap,
-      ev.BatchInput.relatednessThreshold
+      ev.BatchInput.relatednessThreshold,
+      ev.BatchInput.minimumNCount
     );
 
     // we have now detected all the files genomically similar... if asked to, we should also

--- a/application/fingerprint-docker-image/lib/somalier.ts
+++ b/application/fingerprint-docker-image/lib/somalier.ts
@@ -97,12 +97,14 @@ function tsvRecordToMatchType(record: any, f: string): MatchType {
  * @param indexSampleIdToKeyMap the details of the indexes
  * @param sampleIdToKeyMap the details of the comparison samples
  * @param relatednessThreshold the threshold to apply for reporting
+ * @param minimumNCount minimum N count of match to apply for reporting
  */
 export async function extractMatchesAgainstIndexes(
   fingerprintFolder: string,
   indexSampleIdToKeyMap: { [sid: string]: string },
   sampleIdToKeyMap: { [sid: string]: string },
-  relatednessThreshold: number
+  relatednessThreshold: number,
+  minimumNCount: number
 ): Promise<{ [sid: string]: EitherMatchOrNoMatchType[] }> {
   const matches: { [url: string]: EitherMatchOrNoMatchType[] } = {};
 
@@ -135,11 +137,15 @@ export async function extractMatchesAgainstIndexes(
           [record[10], record[11]] = [record[11], record[10]];
         }
 
+        // this is score of sites matching the sites file locations - where this gets very
+        // low the results are less than useful
+        const n = parseInt(record[13]);
+
         // this score is not directional so does not need to be swapped as A<->B swap
         // (it does go negative though - but that just means they really aren't related!)
         const relatedness = parseFloat(record[2]);
 
-        if (relatedness >= relatednessThreshold) {
+        if (relatedness >= relatednessThreshold && n >= minimumNCount) {
           // note it is possible to match against other 'indexes' (not just 'samples')
           // however - we expect that those matches will otherwise be reported correctly when the index
           // *is* eventually compared to the "index as a sample" (maybe in a completely different lambda)

--- a/application/somalier-check-state-machine-construct.ts
+++ b/application/somalier-check-state-machine-construct.ts
@@ -61,6 +61,7 @@ export class SomalierCheckStateMachineConstruct extends SomalierBaseStateMachine
           BatchInput: {
             "indexes.$": "$.indexes",
             "relatednessThreshold.$": "$.relatednessThreshold",
+            "minimumNCount.$": "$.minimumNCount",
             "fingerprintFolder.$": "$.fingerprintFolder",
             "excludeRegex.$": "$.excludeRegex",
             "expectRelatedRegex.$": "$.expectRelatedRegex",
@@ -84,6 +85,8 @@ export class SomalierCheckStateMachineConstruct extends SomalierBaseStateMachine
         parameters: {
           // by default we want to avoid kinship detection in the checking - so setting this high
           relatednessThreshold: 0.8,
+          // by default we get very little value out of comparisons between samples where N is low
+          minimumNCount: 50,
           // this is a regex that by default *won't* exclude anything
           excludeRegex: "^\\b$",
           // this is a regex that by default *won't* match anything - and hence will do no "expected" related checks

--- a/test-e2e/.gitignore
+++ b/test-e2e/.gitignore
@@ -1,0 +1,1 @@
+/pairs.html

--- a/test-e2e/holmes-e2e-test.sh
+++ b/test-e2e/holmes-e2e-test.sh
@@ -45,9 +45,9 @@ case $ACCOUNT in
      . \
      "umccr-fingerprint-local-dev-test" \
      "gds://development/test-data/holmes-test-data" \
-     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierCheckStateMachine1DDB4CFA-VwX5ObSh6X8Y" \
-     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierExtractStateMachine59E102CC-RelluQBfMEYn" \
-     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierPairsStateMachine5E171314-A7MjHNBqvMhJ"
+     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierCheckStateMachine1DDB4CFA-QlEQkSUmc8Qp" \
+     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierExtractStateMachine59E102CC-Lrl1LV43kDPD" \
+     "arn:aws:states:ap-southeast-2:843407916570:stateMachine:SomalierPairsStateMachine5E171314-2f7kcAc92ZDt"
     ;;
 
   *)


### PR DESCRIPTION
Not really tested - as I don't have any particular files with low N. But I think the logic is sound and we have no introduced any regression as the existing test suite is good.

This is to cope with ctTSO samples of poor quality where n is < 10
